### PR TITLE
fix sha256 extraction in iso_urls_update.rb and new qemu builder feature

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+BUILDERS ?= "virtualbox-iso"
 
 all: update build
 
@@ -18,9 +19,9 @@ nixos-x86_64.json: gen_template.rb iso_urls.json
 build: build-i686 build-x86_64
 
 build-i686: nixos-i686.json
-	packer build $<
+	packer build --only=${BUILDERS} $<
 
 build-x86_64: nixos-x86_64.json
-	packer build $<
+	packer build --only=${BUILDERS} $<
 
 .PHONY: all update update_iso update_template build-i686 build-x86_64

--- a/README.md
+++ b/README.md
@@ -26,17 +26,31 @@ Building the images
 -------------------
 
 First install [packer](http://packer.io) and
-[virtualbox](https://www.virtualbox.org/)
+[virtualbox](https://www.virtualbox.org/).
 
-Then:
+Two packer builders are currently supported:
+- Virtualbox
+- qemu / libvirt
 
+To build Virtualbox vagrant images:
 ```
-packer build nixos-i686.json
+packer build --only=virtualbox-iso nixos-i686.json
 # or
-packer build nixos-x86_64.json
+packer build --only=virtualbox-iso nixos-x86_64.json
 ```
 
-The .box image is now ready to go and you can use it in vagrant:
+-or-
+
+To build qemu / libvirt vagrant images:
+```
+packer build --only=qemu nixos-i686.json
+# or
+packer build --only=qemu nixos-x86_64.json
+```
+
+---
+
+The vagrant .box image is now ready to go and you can use it in vagrant:
 
 ```
 vagrant box add nixbox32 packer_virtualbox-iso_virtualbox.box

--- a/gen_template.rb
+++ b/gen_template.rb
@@ -63,6 +63,15 @@ def gen_template(
           ['modifyvm', '{{.Name}}', '--memory', '1024'],
         ],
       ),
+      builder(
+        type: 'qemu',
+        iso_url: iso_url,
+        iso_checksum: iso_sha256,
+        disk_interface: 'virtio-scsi',
+        qemuargs: [
+          ['-m', '1024'],
+        ],
+      ),
     ],
     provisioners: [
       { type: 'shell', script: './scripts/install.sh' }

--- a/iso_urls.json
+++ b/iso_urls.json
@@ -1,10 +1,10 @@
 {
   "x86_64": {
-    "iso_url": "https://d3g5gsiof5omrk.cloudfront.net/nixos/18.03/nixos-18.03.131807.489a14add9a/nixos-minimal-18.03.131807.489a14add9a-x86_64-linux.iso",
-    "iso_sha256": "d4fba36b1c5698090954aaeef8ac2e3fec3c06ddd6aa99f636ebe7a580cec482"
+    "iso_url": "https://d3g5gsiof5omrk.cloudfront.net/nixos/18.09/nixos-18.09.932.09195057114/nixos-minimal-18.09.932.09195057114-x86_64-linux.iso",
+    "iso_sha256": "8da4c81d611f34c33a69f21aa353f08f3504ffb70f1c78417fdb7c5ed7a88eae"
   },
   "i686": {
-    "iso_url": "https://d3g5gsiof5omrk.cloudfront.net/nixos/18.03/nixos-18.03.131807.489a14add9a/nixos-minimal-18.03.131807.489a14add9a-i686-linux.iso",
-    "iso_sha256": "343032acf99a2e5637e9e5d3d0a586d205d5da8bc0e51957a34f9bab1611b10a"
+    "iso_url": "https://d3g5gsiof5omrk.cloudfront.net/nixos/18.09/nixos-18.09.932.09195057114/nixos-minimal-18.09.932.09195057114-i686-linux.iso",
+    "iso_sha256": "6e01f5fb41148ea4626d55cd7e409a3ebce79e96684fdc3ad73a62aa0e9749ec"
   }
 }

--- a/iso_urls_update.rb
+++ b/iso_urls_update.rb
@@ -18,7 +18,7 @@ ISO_RE = /"(https:\/\/[^"]+-([^-]+)-linux.iso)".*Minimal.*"(https:\/\/[^"]+.iso.
 open("https://nixos.org/nixos/download.html").each_line.grep(ISO_RE) do
   isos[$2] = {
     iso_url: $1,
-    iso_sha256: open($3).read.strip,
+    iso_sha256: open($3).read.strip.split.first,
   }
 end
 

--- a/iso_urls_update.rb
+++ b/iso_urls_update.rb
@@ -8,10 +8,6 @@ require 'open-uri'
 require 'uri'
 require 'json'
 
-def get(uri)
-  Net::HTTP.get_response(uri)
-end
-
 isos = {}
 
 ISO_RE = /"(https:\/\/[^"]+-([^-]+)-linux.iso)".*Minimal.*"(https:\/\/[^"]+.iso.sha256)"/i

--- a/nixos-i686.json
+++ b/nixos-i686.json
@@ -15,8 +15,8 @@
       "ssh_port": 22,
       "ssh_username": "root",
       "type": "virtualbox-iso",
-      "iso_url": "https://d3g5gsiof5omrk.cloudfront.net/nixos/18.03/nixos-18.03.131807.489a14add9a/nixos-minimal-18.03.131807.489a14add9a-i686-linux.iso",
-      "iso_checksum": "343032acf99a2e5637e9e5d3d0a586d205d5da8bc0e51957a34f9bab1611b10a",
+      "iso_url": "https://d3g5gsiof5omrk.cloudfront.net/nixos/18.09/nixos-18.09.932.09195057114/nixos-minimal-18.09.932.09195057114-i686-linux.iso",
+      "iso_checksum": "6e01f5fb41148ea4626d55cd7e409a3ebce79e96684fdc3ad73a62aa0e9749ec",
       "guest_additions_mode": "disable",
       "guest_os_type": "Linux",
       "vboxmanage": [
@@ -24,6 +24,31 @@
           "modifyvm",
           "{{.Name}}",
           "--memory",
+          "1024"
+        ]
+      ]
+    },
+    {
+      "boot_wait": "40s",
+      "boot_command": [
+        "echo http://{{ .HTTPIP }}:{{ .HTTPPort}} > .packer_http<enter>",
+        "mkdir -m 0700 .ssh<enter>",
+        "curl $(cat .packer_http)/install_rsa.pub > .ssh/authorized_keys<enter>",
+        "systemctl start sshd<enter>"
+      ],
+      "http_directory": "scripts",
+      "iso_checksum_type": "sha256",
+      "shutdown_command": "shutdown -h now",
+      "ssh_private_key_file": "./scripts/install_rsa",
+      "ssh_port": 22,
+      "ssh_username": "root",
+      "type": "qemu",
+      "iso_url": "https://d3g5gsiof5omrk.cloudfront.net/nixos/18.09/nixos-18.09.932.09195057114/nixos-minimal-18.09.932.09195057114-i686-linux.iso",
+      "iso_checksum": "6e01f5fb41148ea4626d55cd7e409a3ebce79e96684fdc3ad73a62aa0e9749ec",
+      "disk_interface": "virtio-scsi",
+      "qemuargs": [
+        [
+          "-m",
           "1024"
         ]
       ]
@@ -46,8 +71,8 @@
         "only": [
           "virtualbox-iso"
         ],
-        "box_tag": "nixos/nixos-18.03-i686",
-        "version": "18.03.131807-1"
+        "box_tag": "nixos/nixos-18.09-i686",
+        "version": "18.09.932-1"
       }
     ]
   ]

--- a/nixos-x86_64.json
+++ b/nixos-x86_64.json
@@ -15,8 +15,8 @@
       "ssh_port": 22,
       "ssh_username": "root",
       "type": "virtualbox-iso",
-      "iso_url": "https://d3g5gsiof5omrk.cloudfront.net/nixos/18.03/nixos-18.03.131807.489a14add9a/nixos-minimal-18.03.131807.489a14add9a-x86_64-linux.iso",
-      "iso_checksum": "d4fba36b1c5698090954aaeef8ac2e3fec3c06ddd6aa99f636ebe7a580cec482",
+      "iso_url": "https://d3g5gsiof5omrk.cloudfront.net/nixos/18.09/nixos-18.09.932.09195057114/nixos-minimal-18.09.932.09195057114-x86_64-linux.iso",
+      "iso_checksum": "8da4c81d611f34c33a69f21aa353f08f3504ffb70f1c78417fdb7c5ed7a88eae",
       "guest_additions_mode": "disable",
       "guest_os_type": "Linux_64",
       "vboxmanage": [
@@ -24,6 +24,31 @@
           "modifyvm",
           "{{.Name}}",
           "--memory",
+          "1024"
+        ]
+      ]
+    },
+    {
+      "boot_wait": "40s",
+      "boot_command": [
+        "echo http://{{ .HTTPIP }}:{{ .HTTPPort}} > .packer_http<enter>",
+        "mkdir -m 0700 .ssh<enter>",
+        "curl $(cat .packer_http)/install_rsa.pub > .ssh/authorized_keys<enter>",
+        "systemctl start sshd<enter>"
+      ],
+      "http_directory": "scripts",
+      "iso_checksum_type": "sha256",
+      "shutdown_command": "shutdown -h now",
+      "ssh_private_key_file": "./scripts/install_rsa",
+      "ssh_port": 22,
+      "ssh_username": "root",
+      "type": "qemu",
+      "iso_url": "https://d3g5gsiof5omrk.cloudfront.net/nixos/18.09/nixos-18.09.932.09195057114/nixos-minimal-18.09.932.09195057114-x86_64-linux.iso",
+      "iso_checksum": "8da4c81d611f34c33a69f21aa353f08f3504ffb70f1c78417fdb7c5ed7a88eae",
+      "disk_interface": "virtio-scsi",
+      "qemuargs": [
+        [
+          "-m",
           "1024"
         ]
       ]
@@ -46,8 +71,8 @@
         "only": [
           "virtualbox-iso"
         ],
-        "box_tag": "nixos/nixos-18.03-x86_64",
-        "version": "18.03.131807-1"
+        "box_tag": "nixos/nixos-18.09-x86_64",
+        "version": "18.09.932-1"
       }
     ]
   ]


### PR DESCRIPTION
I've been working with nixos a lot and the ```nixbox``` is great for quickly getting started! Sending my thanks out to all contributors.

Noticed there was no qemu-kvm support/vagrant_boxes however (my preference) so decided to add it as an optional builder and contribute back.

Thus, this PR provides the following:

1. 062736b - fix the sha256 field extraction in iso_urls_update.rb

2. cda5b49 - code cleanup

3. 54cedc8 - add support for qemu packer builder. Current ```make``` behavior is maintained; one must opt-in to using the qemu builder.

Usages as follows:
```bash
make # default behavior; use virtualbox-iso builder, vagrant post-processor
make BUILDERS=qemu # use qemu builder, vagrant post-processor
make BUILDERS=virtualbox-iso,qemu # multiple builder support; use virtualbox-iso and qemu builders, plus vagrant post-processor
```

4. 095b77e - bumps iso_urls.json to today's current release version and updates the nixos-{i686,x86_64}.json packer templates with optional qemu support 
