### PR TITLE
Add Hyperv support

### DIFF
--- a/nixos-x86_64.json
+++ b/nixos-x86_64.json
@@ -52,6 +52,36 @@
           "1024"
         ]
       ]
+    },
+    {
+      "boot_wait": "40s",
+      "boot_command": [
+        "echo http://{{.HTTPIP}}:{{.HTTPPort}} > .packer_http<enter>",
+        "mkdir -m 0700 .ssh<enter>",
+        "curl $(cat .packer_http)/install_rsa.pub > .ssh/authorized_keys<enter><wait>",
+        "sed -i '5ivirtualisation.hypervGuest.enable = true;' /etc/nixos/configuration.nix<enter><wait>",
+        "sed -i '6idocumentation.man.enable = false; documentation.enable = false;' /etc/nixos/configuration.nix<enter><wait>",
+        "sed -i '7iservices.nixosManual.enable = false;' /etc/nixos/configuration.nix<enter><wait>",
+        "nixos-rebuild switch<enter><wait>",
+        "systemctl start sshd<enter>"
+      ],
+      "http_directory": "scripts",
+      "switch_name": "Devbox",
+      "iso_checksum_type": "sha256",
+      "shutdown_command": "shutdown -h now",
+      "ssh_private_key_file": "./scripts/install_rsa",
+      "ssh_port": 22,
+      "ssh_timeout": "600s",
+      "ssh_username": "root",
+      "type": "hyperv-iso",
+      "iso_url": "https://d3g5gsiof5omrk.cloudfront.net/nixos/18.09/nixos-18.09.1534.d45a0d7a4f5/nixos-minimal-18.09.1534.d45a0d7a4f5-x86_64-linux.iso",
+      "iso_checksum": "8da4c81d611f34c33a69f21aa353f08f3504ffb70f1c78417fdb7c5ed7a88eae",
+      "disk_size": 62000,
+      "cpu": 3,
+      "ram_size": 2048,
+      "enable_mac_spoofing": true,
+      "guest_additions_mode": "disable",
+      "enable_virtualization_extensions": false
     }
   ],
   "provisioners": [

--- a/scripts/configuration.nix
+++ b/scripts/configuration.nix
@@ -5,6 +5,7 @@
     [ # Include the results of the hardware scan.
       ./hardware-configuration.nix
       ./vagrant.nix
+      ./custom-configuration.nix
     ];
 
   # Use the GRUB 2 boot loader.
@@ -26,9 +27,6 @@
 
   # Replace nptd by timesyncd
   services.timesyncd.enable = true;
-
-  # Enable guest additions.
-  virtualisation.virtualbox.guest.enable = true;
 
   # Packages for Vagrant
   environment.systemPackages = with pkgs; [

--- a/scripts/custom-configuration.nix
+++ b/scripts/custom-configuration.nix
@@ -1,0 +1,9 @@
+# Place here any custom configuration specific to your organisation (locale, hypervisor, ...)
+# if you want it to be part of the packer base image to be used with vagrant.
+{ config, pkgs, ... }:
+
+{
+  # Enable guest additions.
+  virtualisation.hypervGuest.enable = false;
+  virtualisation.virtualbox.guest.enable = true;
+}

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -25,6 +25,7 @@ nixos-generate-config --root /mnt
 curl -f "$packer_http/vagrant.nix" > /mnt/etc/nixos/vagrant.nix
 curl -f "$packer_http/vagrant-hostname.nix" > /mnt/etc/nixos/vagrant-hostname.nix
 curl -f "$packer_http/vagrant-network.nix" > /mnt/etc/nixos/vagrant-network.nix
+curl -f "$packer_http/custom-configuration.nix" > /mnt/etc/nixos/custom-configuration.nix
 curl -f "$packer_http/configuration.nix" > /mnt/etc/nixos/configuration.nix
 
 ### Install ###


### PR DESCRIPTION
 This is an attemps to fix #26. 

It works on Windows 10 if you use a specific network external adapter. 

Any comment, suggestion is welcomed.

I also took the liberty to add a hook so I can make heavier packer images. This need cames from the need to debug the vagrant box part of the generated hyperv box.