### PR TITLE
WIP: Bump build template to support NixOS 19.09.

### DIFF
--- a/gen_template.rb
+++ b/gen_template.rb
@@ -20,7 +20,7 @@ def builder(**opts)
       'echo http://{{ .HTTPIP }}:{{ .HTTPPort}} > .packer_http<enter>',
       'mkdir -m 0700 .ssh<enter>',
       'curl $(cat .packer_http)/install_rsa.pub > .ssh/authorized_keys<enter>',
-      'systemctl start sshd<enter>',
+      'sudo systemctl start sshd<enter>',
     ],
     http_directory: 'scripts',
     iso_checksum_type: 'sha256',

--- a/nixos-x86_64.json
+++ b/nixos-x86_64.json
@@ -6,7 +6,7 @@
         "echo http://{{ .HTTPIP }}:{{ .HTTPPort}} > .packer_http<enter>",
         "mkdir -m 0700 .ssh<enter>",
         "curl $(cat .packer_http)/install_rsa.pub > .ssh/authorized_keys<enter>",
-        "systemctl start sshd<enter>"
+        "sudo systemctl start sshd<enter>"
       ],
       "http_directory": "scripts",
       "iso_checksum_type": "sha256",
@@ -35,7 +35,7 @@
         "echo http://{{ .HTTPIP }}:{{ .HTTPPort}} > .packer_http<enter>",
         "mkdir -m 0700 .ssh<enter>",
         "curl $(cat .packer_http)/install_rsa.pub > .ssh/authorized_keys<enter>",
-        "systemctl start sshd<enter>"
+        "sudo systemctl start sshd<enter>"
       ],
       "http_directory": "scripts",
       "iso_checksum_type": "sha256",
@@ -60,7 +60,7 @@
         "echo http://{{ .HTTPIP }}:{{ .HTTPPort}} > .packer_http<enter>",
         "mkdir -m 0700 .ssh<enter>",
         "curl $(cat .packer_http)/install_rsa.pub > .ssh/authorized_keys<enter>",
-        "systemctl start sshd<enter>"
+        "sudo systemctl start sshd<enter>"
       ],
       "http_directory": "scripts",
       "iso_checksum_type": "sha256",


### PR DESCRIPTION
NixOS 19.09 adds a nixos user and blocks on user input asking which user to
start `sshd` with. Using sudo bypasses this prompt.