### PR TITLE
Fix password-less sudo access for "vagrant" user

### DIFF
--- a/scripts/configuration.nix
+++ b/scripts/configuration.nix
@@ -63,7 +63,7 @@
     ];
   };
 
-  security.sudo.configFile =
+  security.sudo.extraConfig =
     ''
       Defaults:root,%wheel env_keep+=LOCALE_ARCHIVE
       Defaults:root,%wheel env_keep+=NIX_PATH


### PR DESCRIPTION
We currently have a regression in the image, see an example issue here: https://github.com/nix-community/vagrant-nixos-plugin/issues/15

The PR fixes the order in sudoers in order to yield the expected behavior. 