### PR TITLE
Provide a proper output name for the files

### DIFF
--- a/gen_template.rb
+++ b/gen_template.rb
@@ -94,7 +94,8 @@ def gen_template(
       {
         type: 'vagrant',
         keep_input_artifact: false,
-        only: [ 'virtualbox-iso', 'qemu']
+        only: [ 'virtualbox-iso', 'qemu'],
+        output: "nixos-#{ver}-{{.Provider}}-#{arch}.box"
       }
     ]],
   )

--- a/nixos-i686.json
+++ b/nixos-i686.json
@@ -96,7 +96,8 @@
         "only": [
           "virtualbox-iso",
           "qemu"
-        ]
+        ],
+        "output": "nixos-19.09-{{.Provider}}-i686.box"
       }
     ]
   ]

--- a/nixos-x86_64.json
+++ b/nixos-x86_64.json
@@ -96,7 +96,8 @@
         "only": [
           "virtualbox-iso",
           "qemu"
-        ]
+        ],
+        "output": "nixos-19.09-{{.Provider}}-x86_64.box"
       }
     ]
   ]


### PR DESCRIPTION
Something like nixos-19.09-libvirt-x86_64.box will be generated.