### PR TITLE
cdituri/feature/qemu leverage qcow2 disk format

### DIFF
--- a/gen_template.rb
+++ b/gen_template.rb
@@ -77,6 +77,7 @@ def gen_template(
         iso_checksum: iso_sha256,
         disk_interface: 'virtio-scsi',
         disk_size: '{{ user `disk_size` }}',
+        format: 'qcow2',
         qemuargs: [
           ['-m', '{{ user `memory` }}'],
         ],

--- a/gen_template.rb
+++ b/gen_template.rb
@@ -54,6 +54,10 @@ def gen_template(
     end
 
   puts JSON.pretty_generate(
+    variables: {
+      disk_size: '10240',
+      memory: '1024',
+    },
     builders: [
       builder(
         type: 'virtualbox-iso',
@@ -62,9 +66,9 @@ def gen_template(
         guest_additions_mode: 'disable',
         format: 'ova',
         guest_os_type: guest_os_type,
-        disk_size: 57000,
+        disk_size: '{{ user `disk_size` }}',
         vboxmanage: [
-          ['modifyvm', '{{.Name}}', '--memory', '1024', '--vram', '128', '--clipboard', 'bidirectional'],
+          ['modifyvm', '{{.Name}}', '--memory', '{{ user `memory` }}', '--vram', '128', '--clipboard', 'bidirectional'],
         ],
       ),
       builder(
@@ -72,16 +76,17 @@ def gen_template(
         iso_url: iso_url,
         iso_checksum: iso_sha256,
         disk_interface: 'virtio-scsi',
+        disk_size: '{{ user `disk_size` }}',
         qemuargs: [
-          ['-m', '1024'],
+          ['-m', '{{ user `memory` }}'],
         ],
       ),
       builder(
         type: 'vmware-iso',
         iso_url: iso_url,
         iso_checksum: iso_sha256,
-        memory: 1024,
-        disk_size: 62000,
+        memory: '{{ user `memory` }}',
+        disk_size: '{{ user `disk_size` }}',
         guest_os_type: "Linux"
       ),
     ],

--- a/nixos-i686.json
+++ b/nixos-i686.json
@@ -1,4 +1,8 @@
 {
+  "variables": {
+    "disk_size": "10240",
+    "memory": "1024"
+  },
   "builders": [
     {
       "boot_wait": "45s",
@@ -21,13 +25,13 @@
       "guest_additions_mode": "disable",
       "format": "ova",
       "guest_os_type": "Linux",
-      "disk_size": 57000,
+      "disk_size": "{{ user `disk_size` }}",
       "vboxmanage": [
         [
           "modifyvm",
           "{{.Name}}",
           "--memory",
-          "1024",
+          "{{ user `memory` }}",
           "--vram",
           "128",
           "--clipboard",
@@ -54,10 +58,12 @@
       "iso_url": "https://releases.nixos.org/nixos/19.09/nixos-19.09.741.dbad7c7d59f/nixos-minimal-19.09.741.dbad7c7d59f-i686-linux.iso",
       "iso_checksum": "c68dc1f70814d7194280f0ee5e39368408146c31757b39ec97d1f2d531b0b4b0",
       "disk_interface": "virtio-scsi",
+      "disk_size": "{{ user `disk_size` }}",
+      "format": "qcow2",
       "qemuargs": [
         [
           "-m",
-          "1024"
+          "{{ user `memory` }}"
         ]
       ]
     },
@@ -79,8 +85,8 @@
       "type": "vmware-iso",
       "iso_url": "https://releases.nixos.org/nixos/19.09/nixos-19.09.741.dbad7c7d59f/nixos-minimal-19.09.741.dbad7c7d59f-i686-linux.iso",
       "iso_checksum": "c68dc1f70814d7194280f0ee5e39368408146c31757b39ec97d1f2d531b0b4b0",
-      "memory": 1024,
-      "disk_size": 62000,
+      "memory": "{{ user `memory` }}",
+      "disk_size": "{{ user `disk_size` }}",
       "guest_os_type": "Linux"
     }
   ],

--- a/nixos-x86_64.json
+++ b/nixos-x86_64.json
@@ -1,4 +1,8 @@
 {
+  "variables": {
+    "disk_size": "10240",
+    "memory": "1024"
+  },
   "builders": [
     {
       "boot_wait": "45s",
@@ -21,13 +25,13 @@
       "guest_additions_mode": "disable",
       "format": "ova",
       "guest_os_type": "Linux_64",
-      "disk_size": 57000,
+      "disk_size": "{{ user `disk_size` }}",
       "vboxmanage": [
         [
           "modifyvm",
           "{{.Name}}",
           "--memory",
-          "1024",
+          "{{ user `memory` }}",
           "--vram",
           "128",
           "--clipboard",
@@ -54,10 +58,12 @@
       "iso_url": "https://releases.nixos.org/nixos/19.09/nixos-19.09.741.dbad7c7d59f/nixos-minimal-19.09.741.dbad7c7d59f-x86_64-linux.iso",
       "iso_checksum": "3379a53f998ca7bdc9b775a06d81275df7bd2c002e7d0fa0a3036cad9c3b7aca",
       "disk_interface": "virtio-scsi",
+      "disk_size": "{{ user `disk_size` }}",
+      "format": "qcow2",
       "qemuargs": [
         [
           "-m",
-          "1024"
+          "{{ user `memory` }}"
         ]
       ]
     },
@@ -79,8 +85,8 @@
       "type": "vmware-iso",
       "iso_url": "https://releases.nixos.org/nixos/19.09/nixos-19.09.741.dbad7c7d59f/nixos-minimal-19.09.741.dbad7c7d59f-x86_64-linux.iso",
       "iso_checksum": "3379a53f998ca7bdc9b775a06d81275df7bd2c002e7d0fa0a3036cad9c3b7aca",
-      "memory": 1024,
-      "disk_size": 62000,
+      "memory": "{{ user `memory` }}",
+      "disk_size": "{{ user `disk_size` }}",
       "guest_os_type": "Linux"
     }
   ],

--- a/scripts/postinstall.sh
+++ b/scripts/postinstall.sh
@@ -10,10 +10,15 @@ for x in $(seq 0 2) ; do
   nix-collect-garbage -d
 done
 
-
 # Remove install ssh key
 rm -rf /root/.ssh /root/.packer_http
 
-# Zero out the disk (for better compression)
-dd if=/dev/zero of=/EMPTY bs=1M
-rm -rf /EMPTY
+if [[ "${PACKER_BUILDER_TYPE}" == "qemu" ]] ; then
+  echo "skipping disk zero out!"
+else
+  echo "zeroing out the disk..."
+
+  # Zero out the disk (for better compression)
+  dd if=/dev/zero of=/EMPTY bs=1M
+  rm -rf /EMPTY
+fi


### PR DESCRIPTION
Greetings `nix-community/nixbox` maintainers, thank you for your efforts!

This pull request does two things:
* Introduces `disk_size` and `memory` packer (build-time) variables, and their defaults. Usage example:
```bash
packer build -var 'disk_size=40960' -var 'memory=4096' -only qemu nixos-x86_64.json
``` 

* Switches the `qemu/libvirt` builder to leverage `qcow2` for better efficiency and thinly provisioned disks. As a result, we skip disk zero-out in the `postinstall.sh` when `$PACKER_BUILDER_TYPE` is `qemu`, since the backing image is sparse to begin with.

Resultant `qemu/libvrit` `qcow2` backed vagrant `.box` for the packer "usage example" above: 
```bash
$ du -h nixos-19.09-libvirt-x86_64.box 
3.2G	nixos-19.09-libvirt-x86_64.box
```