### PR TITLE
cdituri/feature/hyperv packer builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Three packer builders are currently supported:
 - Virtualbox
 - qemu / libvirt
 - VMware
+- Hyper-V
 
 Have a look at the different `make build` target to build your image.
 
@@ -40,6 +41,7 @@ If you build on a host that does not support Makefile, here are some examples:
 packer build --only=virtualbox-iso nixos-i686.json
 packer build --only=qemu nixos-x86_64.json
 packer build --only=vmware-iso nixos-x86_64.json
+packer build --only=hyperv-iso nixos-x86_64.json
 ```
 
 The vagrant .box image is now ready to go and you can use it in vagrant:

--- a/iso_urls.json
+++ b/iso_urls.json
@@ -1,10 +1,10 @@
 {
   "x86_64": {
-    "iso_url": "https://releases.nixos.org/nixos/19.09/nixos-19.09.741.dbad7c7d59f/nixos-minimal-19.09.741.dbad7c7d59f-x86_64-linux.iso",
-    "iso_sha256": "3379a53f998ca7bdc9b775a06d81275df7bd2c002e7d0fa0a3036cad9c3b7aca"
+    "iso_url": "https://channels.nixos.org/nixos-20.03/latest-nixos-minimal-x86_64-linux.iso",
+    "iso_sha256": "8703dce034f87b8f26d5de834b3f27a76e5aa3251a326390e803b0bdf4545487"
   },
   "i686": {
-    "iso_url": "https://releases.nixos.org/nixos/19.09/nixos-19.09.741.dbad7c7d59f/nixos-minimal-19.09.741.dbad7c7d59f-i686-linux.iso",
-    "iso_sha256": "c68dc1f70814d7194280f0ee5e39368408146c31757b39ec97d1f2d531b0b4b0"
+    "iso_url": "https://channels.nixos.org/nixos-20.03/latest-nixos-minimal-i686-linux.iso",
+    "iso_sha256": "7dd0c8a82faef41742dc57ad4c68630a6eea8641dfaeae64960eba47e16082a6"
   }
 }

--- a/nixos-i686.json
+++ b/nixos-i686.json
@@ -20,8 +20,8 @@
       "ssh_username": "nixos",
       "headless": true,
       "type": "virtualbox-iso",
-      "iso_url": "https://releases.nixos.org/nixos/19.09/nixos-19.09.741.dbad7c7d59f/nixos-minimal-19.09.741.dbad7c7d59f-i686-linux.iso",
-      "iso_checksum": "c68dc1f70814d7194280f0ee5e39368408146c31757b39ec97d1f2d531b0b4b0",
+      "iso_url": "https://channels.nixos.org/nixos-20.03/latest-nixos-minimal-i686-linux.iso",
+      "iso_checksum": "7dd0c8a82faef41742dc57ad4c68630a6eea8641dfaeae64960eba47e16082a6",
       "guest_additions_mode": "disable",
       "format": "ova",
       "guest_os_type": "Linux",
@@ -55,8 +55,8 @@
       "ssh_username": "nixos",
       "headless": true,
       "type": "qemu",
-      "iso_url": "https://releases.nixos.org/nixos/19.09/nixos-19.09.741.dbad7c7d59f/nixos-minimal-19.09.741.dbad7c7d59f-i686-linux.iso",
-      "iso_checksum": "c68dc1f70814d7194280f0ee5e39368408146c31757b39ec97d1f2d531b0b4b0",
+      "iso_url": "https://channels.nixos.org/nixos-20.03/latest-nixos-minimal-i686-linux.iso",
+      "iso_checksum": "7dd0c8a82faef41742dc57ad4c68630a6eea8641dfaeae64960eba47e16082a6",
       "disk_interface": "virtio-scsi",
       "disk_size": "{{ user `disk_size` }}",
       "format": "qcow2",
@@ -66,6 +66,36 @@
           "{{ user `memory` }}"
         ]
       ]
+    },
+    {
+      "boot_wait": "60s",
+      "boot_command": [
+        "echo http://{{ .HTTPIP }}:{{ .HTTPPort}} > .packer_http<enter>",
+        "mkdir -m 0700 .ssh<enter>",
+        "curl $(cat .packer_http)/install_rsa.pub > .ssh/authorized_keys<enter>",
+        "sudo su --<enter>",
+        "nix-env -iA nixos.linuxPackages.hyperv-daemons<enter><wait10>",
+        "$(find /nix/store -executable -iname 'hv_kvp_daemon' | head -n 1)<enter><wait10>",
+        "systemctl start sshd<enter>"
+      ],
+      "http_directory": "scripts",
+      "iso_checksum_type": "sha256",
+      "shutdown_command": "sudo shutdown -h now",
+      "ssh_private_key_file": "./scripts/install_rsa",
+      "ssh_port": 22,
+      "ssh_username": "nixos",
+      "headless": true,
+      "type": "hyperv-iso",
+      "generation": 1,
+      "iso_url": "https://channels.nixos.org/nixos-20.03/latest-nixos-minimal-i686-linux.iso",
+      "iso_checksum": "7dd0c8a82faef41742dc57ad4c68630a6eea8641dfaeae64960eba47e16082a6",
+      "memory": "{{ user `memory` }}",
+      "disk_size": "{{ user `disk_size` }}",
+      "enable_secure_boot": false,
+      "switch_name": "Default Switch",
+      "differencing_disk": true,
+      "communicator": "ssh",
+      "ssh_timeout": "1h"
     },
     {
       "boot_wait": "45s",
@@ -83,8 +113,8 @@
       "ssh_username": "nixos",
       "headless": true,
       "type": "vmware-iso",
-      "iso_url": "https://releases.nixos.org/nixos/19.09/nixos-19.09.741.dbad7c7d59f/nixos-minimal-19.09.741.dbad7c7d59f-i686-linux.iso",
-      "iso_checksum": "c68dc1f70814d7194280f0ee5e39368408146c31757b39ec97d1f2d531b0b4b0",
+      "iso_url": "https://channels.nixos.org/nixos-20.03/latest-nixos-minimal-i686-linux.iso",
+      "iso_checksum": "7dd0c8a82faef41742dc57ad4c68630a6eea8641dfaeae64960eba47e16082a6",
       "memory": "{{ user `memory` }}",
       "disk_size": "{{ user `disk_size` }}",
       "guest_os_type": "Linux"
@@ -104,9 +134,10 @@
         "keep_input_artifact": false,
         "only": [
           "virtualbox-iso",
-          "qemu"
+          "qemu",
+          "hyperv-iso"
         ],
-        "output": "nixos-19.09-{{.Provider}}-i686.box"
+        "output": "nixos-20.03-{{.Provider}}-i686.box"
       }
     ]
   ]

--- a/nixos-x86_64.json
+++ b/nixos-x86_64.json
@@ -20,8 +20,8 @@
       "ssh_username": "nixos",
       "headless": true,
       "type": "virtualbox-iso",
-      "iso_url": "https://releases.nixos.org/nixos/19.09/nixos-19.09.741.dbad7c7d59f/nixos-minimal-19.09.741.dbad7c7d59f-x86_64-linux.iso",
-      "iso_checksum": "3379a53f998ca7bdc9b775a06d81275df7bd2c002e7d0fa0a3036cad9c3b7aca",
+      "iso_url": "https://channels.nixos.org/nixos-20.03/latest-nixos-minimal-x86_64-linux.iso",
+      "iso_checksum": "8703dce034f87b8f26d5de834b3f27a76e5aa3251a326390e803b0bdf4545487",
       "guest_additions_mode": "disable",
       "format": "ova",
       "guest_os_type": "Linux_64",
@@ -55,8 +55,8 @@
       "ssh_username": "nixos",
       "headless": true,
       "type": "qemu",
-      "iso_url": "https://releases.nixos.org/nixos/19.09/nixos-19.09.741.dbad7c7d59f/nixos-minimal-19.09.741.dbad7c7d59f-x86_64-linux.iso",
-      "iso_checksum": "3379a53f998ca7bdc9b775a06d81275df7bd2c002e7d0fa0a3036cad9c3b7aca",
+      "iso_url": "https://channels.nixos.org/nixos-20.03/latest-nixos-minimal-x86_64-linux.iso",
+      "iso_checksum": "8703dce034f87b8f26d5de834b3f27a76e5aa3251a326390e803b0bdf4545487",
       "disk_interface": "virtio-scsi",
       "disk_size": "{{ user `disk_size` }}",
       "format": "qcow2",
@@ -66,6 +66,36 @@
           "{{ user `memory` }}"
         ]
       ]
+    },
+    {
+      "boot_wait": "60s",
+      "boot_command": [
+        "echo http://{{ .HTTPIP }}:{{ .HTTPPort}} > .packer_http<enter>",
+        "mkdir -m 0700 .ssh<enter>",
+        "curl $(cat .packer_http)/install_rsa.pub > .ssh/authorized_keys<enter>",
+        "sudo su --<enter>",
+        "nix-env -iA nixos.linuxPackages.hyperv-daemons<enter><wait10>",
+        "$(find /nix/store -executable -iname 'hv_kvp_daemon' | head -n 1)<enter><wait10>",
+        "systemctl start sshd<enter>"
+      ],
+      "http_directory": "scripts",
+      "iso_checksum_type": "sha256",
+      "shutdown_command": "sudo shutdown -h now",
+      "ssh_private_key_file": "./scripts/install_rsa",
+      "ssh_port": 22,
+      "ssh_username": "nixos",
+      "headless": true,
+      "type": "hyperv-iso",
+      "generation": 1,
+      "iso_url": "https://channels.nixos.org/nixos-20.03/latest-nixos-minimal-x86_64-linux.iso",
+      "iso_checksum": "8703dce034f87b8f26d5de834b3f27a76e5aa3251a326390e803b0bdf4545487",
+      "memory": "{{ user `memory` }}",
+      "disk_size": "{{ user `disk_size` }}",
+      "enable_secure_boot": false,
+      "switch_name": "Default Switch",
+      "differencing_disk": true,
+      "communicator": "ssh",
+      "ssh_timeout": "1h"
     },
     {
       "boot_wait": "45s",
@@ -83,8 +113,8 @@
       "ssh_username": "nixos",
       "headless": true,
       "type": "vmware-iso",
-      "iso_url": "https://releases.nixos.org/nixos/19.09/nixos-19.09.741.dbad7c7d59f/nixos-minimal-19.09.741.dbad7c7d59f-x86_64-linux.iso",
-      "iso_checksum": "3379a53f998ca7bdc9b775a06d81275df7bd2c002e7d0fa0a3036cad9c3b7aca",
+      "iso_url": "https://channels.nixos.org/nixos-20.03/latest-nixos-minimal-x86_64-linux.iso",
+      "iso_checksum": "8703dce034f87b8f26d5de834b3f27a76e5aa3251a326390e803b0bdf4545487",
       "memory": "{{ user `memory` }}",
       "disk_size": "{{ user `disk_size` }}",
       "guest_os_type": "Linux"
@@ -104,9 +134,10 @@
         "keep_input_artifact": false,
         "only": [
           "virtualbox-iso",
-          "qemu"
+          "qemu",
+          "hyperv-iso"
         ],
-        "output": "nixos-19.09-{{.Provider}}-x86_64.box"
+        "output": "nixos-20.03-{{.Provider}}-x86_64.box"
       }
     ]
   ]

--- a/scripts/builders/hyperv-iso.nix
+++ b/scripts/builders/hyperv-iso.nix
@@ -1,0 +1,13 @@
+{ config, pkgs, ... }:
+
+{
+  # Enable guest additions.
+  virtualisation.hypervGuest.enable = true;
+
+  # Enable systemd efi bootloader
+  boot.loader.systemd-boot.enable   = true;
+
+  environment.systemPackages = with pkgs; [
+    cifs-utils
+  ];
+}


### PR DESCRIPTION
### Overview

This pull request adds `hyperv-iso` builder support to `nix-community/nixbox`:

  * add hyperv packer builder
  * add hyperv-iso.nix builder
  * regenerate iso_urls.json, nixos-i686.json, and nixos-x86_64.json

**!!! Important:** the last commit in the series brings `iso_urls.json`, `nixos-i686.json`, and `nixos-x86_64.json` to current. This is note-worthy because it looks like NixOS upstream is now using a 'latest' `.iso` release, and we leverage that new approach here as well.

---

### Steps

Run packer build:
```shell
packer build -force -var "memory=2048" -var "disk_size=10280" -on-error=ask -only=hyperv-iso .\nixos-x86_64.json
```

Import resultant vagrant `.box` image:
```shell
vagrant box add --force --name hyperv/nixos-x86_64 .\nixos-19.09-hyperv-x86_64.box
```

Run vagrant:
```
vagrant init hyperv/nixos-x86_64
vagrant up --provider=hyperv
```

---

**Final note:** many individuals on Windows have `git config --global core.autocrlf true` set, myself included. Having `autocrlf` set caused the following error during packer build, after a fresh clone:

```
==> hyperv-iso: Installation finished. No error reported.
    hyperv-iso: installation finished!
==> hyperv-iso:   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
==> hyperv-iso:                                  Dload  Upload   Total   Spent    Left  Speed
==> hyperv-iso: 100   524  100   524    0     0  32750      0 --:--:-- --:--:-- --:--:-- 34933
==> hyperv-iso: setting up /etc...
==> hyperv-iso: /nix/var/nix/profiles/system/sw/bin/bash: line 2: $'\r': command not found
==> hyperv-iso: /nix/var/nix/profiles/system/sw/bin/bash: line 4: $'\r': command not found
==> hyperv-iso: /nix/var/nix/profiles/system/sw/bin/bash: line 7: $'\r': command not found
==> hyperv-iso: /nix/var/nix/profiles/system/sw/bin/bash: line 8: syntax error near unexpected token `$'do\r''
==> hyperv-iso: '
    hyperv-iso: Start postinstall ...
==> hyperv-iso: Script exited with non-zero exit status: 2.Allowed exit codes are: [0]
==> hyperv-iso: Step "StepProvision" failed
==> hyperv-iso: [c] Clean up and exit, [a] abort without cleanup, or [r] retry step (build may fail even if retry succeeds)?
```

If you see this error, its because `scripts/{install, post-install}.sh` need to be LF; and `git` on Windows has presumably checked them out with CRLF line-endings on clone/checkout. 