### PR TITLE
Fix selector for new website

### DIFF
--- a/iso_urls_update.rb
+++ b/iso_urls_update.rb
@@ -12,7 +12,7 @@ include REXML
 isos = {}
 
 xml = Document.new(open("https://nixos.org/nixos/download.html"))
-xml.root.elements.each("body/*/*/*/ul/li") { |li|
+xml.root.elements.each("body/*/*/*/*/*/ul/li") { |li|
   hrefs = li.get_elements("a").map { |a| a.attribute("href") }
   if hrefs.size == 2 and /.*minimal.*/i =~ hrefs[0].value
   then


### PR DESCRIPTION
The old selector didn't work with the new website and generated an empty json file. This little change fixes that.