### PR TITLE
Update ISO URLs for NixOS 21.05

### DIFF
--- a/iso_urls.json
+++ b/iso_urls.json
@@ -1,10 +1,10 @@
 {
   "x86_64": {
-    "iso_url": "https://channels.nixos.org/nixos-20.09/latest-nixos-minimal-x86_64-linux.iso",
-    "iso_sha256": "4dcda77f30ff97832b80b74686068c896674d09c9b222e6c05f85f91cbbbbc5b"
+    "iso_url": "https://channels.nixos.org/nixos-21.05/latest-nixos-minimal-x86_64-linux.iso",
+    "iso_sha256": "9e66b8f763cf66ca1ce0f0556e52466c91b68a58b503b086348017ace04f2437"
   },
   "i686": {
-    "iso_url": "https://channels.nixos.org/nixos-20.09/latest-nixos-minimal-i686-linux.iso",
-    "iso_sha256": "52726541ed2f334d9099d1eadc4849feafc405c3868c6b2a71e7580c12b5d8bb"
+    "iso_url": "https://channels.nixos.org/nixos-21.05/latest-nixos-minimal-i686-linux.iso",
+    "iso_sha256": "4f81287ed0f516e551d9686df6c871760f41c8413d2957f9afbd1c8d4fbfd38e"
   }
 }

--- a/nixos-i686.json
+++ b/nixos-i686.json
@@ -19,8 +19,8 @@
       "ssh_username": "nixos",
       "headless": true,
       "type": "virtualbox-iso",
-      "iso_url": "https://channels.nixos.org/nixos-20.09/latest-nixos-minimal-i686-linux.iso",
-      "iso_checksum": "52726541ed2f334d9099d1eadc4849feafc405c3868c6b2a71e7580c12b5d8bb",
+      "iso_url": "https://channels.nixos.org/nixos-21.05/latest-nixos-minimal-i686-linux.iso",
+      "iso_checksum": "4f81287ed0f516e551d9686df6c871760f41c8413d2957f9afbd1c8d4fbfd38e",
       "guest_additions_mode": "disable",
       "format": "ova",
       "guest_os_type": "Linux",
@@ -53,8 +53,8 @@
       "ssh_username": "nixos",
       "headless": true,
       "type": "qemu",
-      "iso_url": "https://channels.nixos.org/nixos-20.09/latest-nixos-minimal-i686-linux.iso",
-      "iso_checksum": "52726541ed2f334d9099d1eadc4849feafc405c3868c6b2a71e7580c12b5d8bb",
+      "iso_url": "https://channels.nixos.org/nixos-21.05/latest-nixos-minimal-i686-linux.iso",
+      "iso_checksum": "4f81287ed0f516e551d9686df6c871760f41c8413d2957f9afbd1c8d4fbfd38e",
       "disk_interface": "virtio-scsi",
       "disk_size": "{{ user `disk_size` }}",
       "format": "qcow2",
@@ -84,8 +84,8 @@
       "headless": true,
       "type": "hyperv-iso",
       "generation": 1,
-      "iso_url": "https://channels.nixos.org/nixos-20.09/latest-nixos-minimal-i686-linux.iso",
-      "iso_checksum": "52726541ed2f334d9099d1eadc4849feafc405c3868c6b2a71e7580c12b5d8bb",
+      "iso_url": "https://channels.nixos.org/nixos-21.05/latest-nixos-minimal-i686-linux.iso",
+      "iso_checksum": "4f81287ed0f516e551d9686df6c871760f41c8413d2957f9afbd1c8d4fbfd38e",
       "memory": "{{ user `memory` }}",
       "disk_size": "{{ user `disk_size` }}",
       "enable_secure_boot": false,
@@ -109,8 +109,8 @@
       "ssh_username": "nixos",
       "headless": true,
       "type": "vmware-iso",
-      "iso_url": "https://channels.nixos.org/nixos-20.09/latest-nixos-minimal-i686-linux.iso",
-      "iso_checksum": "52726541ed2f334d9099d1eadc4849feafc405c3868c6b2a71e7580c12b5d8bb",
+      "iso_url": "https://channels.nixos.org/nixos-21.05/latest-nixos-minimal-i686-linux.iso",
+      "iso_checksum": "4f81287ed0f516e551d9686df6c871760f41c8413d2957f9afbd1c8d4fbfd38e",
       "memory": "{{ user `memory` }}",
       "disk_size": "{{ user `disk_size` }}",
       "guest_os_type": "Linux"
@@ -133,7 +133,7 @@
           "qemu",
           "hyperv-iso"
         ],
-        "output": "nixos-20.09-{{.Provider}}-i686.box"
+        "output": "nixos-21.05-{{.Provider}}-i686.box"
       }
     ]
   ]

--- a/nixos-x86_64.json
+++ b/nixos-x86_64.json
@@ -19,8 +19,8 @@
       "ssh_username": "nixos",
       "headless": true,
       "type": "virtualbox-iso",
-      "iso_url": "https://channels.nixos.org/nixos-20.09/latest-nixos-minimal-x86_64-linux.iso",
-      "iso_checksum": "4dcda77f30ff97832b80b74686068c896674d09c9b222e6c05f85f91cbbbbc5b",
+      "iso_url": "https://channels.nixos.org/nixos-21.05/latest-nixos-minimal-x86_64-linux.iso",
+      "iso_checksum": "9e66b8f763cf66ca1ce0f0556e52466c91b68a58b503b086348017ace04f2437",
       "guest_additions_mode": "disable",
       "format": "ova",
       "guest_os_type": "Linux_64",
@@ -53,8 +53,8 @@
       "ssh_username": "nixos",
       "headless": true,
       "type": "qemu",
-      "iso_url": "https://channels.nixos.org/nixos-20.09/latest-nixos-minimal-x86_64-linux.iso",
-      "iso_checksum": "4dcda77f30ff97832b80b74686068c896674d09c9b222e6c05f85f91cbbbbc5b",
+      "iso_url": "https://channels.nixos.org/nixos-21.05/latest-nixos-minimal-x86_64-linux.iso",
+      "iso_checksum": "9e66b8f763cf66ca1ce0f0556e52466c91b68a58b503b086348017ace04f2437",
       "disk_interface": "virtio-scsi",
       "disk_size": "{{ user `disk_size` }}",
       "format": "qcow2",
@@ -84,8 +84,8 @@
       "headless": true,
       "type": "hyperv-iso",
       "generation": 1,
-      "iso_url": "https://channels.nixos.org/nixos-20.09/latest-nixos-minimal-x86_64-linux.iso",
-      "iso_checksum": "4dcda77f30ff97832b80b74686068c896674d09c9b222e6c05f85f91cbbbbc5b",
+      "iso_url": "https://channels.nixos.org/nixos-21.05/latest-nixos-minimal-x86_64-linux.iso",
+      "iso_checksum": "9e66b8f763cf66ca1ce0f0556e52466c91b68a58b503b086348017ace04f2437",
       "memory": "{{ user `memory` }}",
       "disk_size": "{{ user `disk_size` }}",
       "enable_secure_boot": false,
@@ -109,8 +109,8 @@
       "ssh_username": "nixos",
       "headless": true,
       "type": "vmware-iso",
-      "iso_url": "https://channels.nixos.org/nixos-20.09/latest-nixos-minimal-x86_64-linux.iso",
-      "iso_checksum": "4dcda77f30ff97832b80b74686068c896674d09c9b222e6c05f85f91cbbbbc5b",
+      "iso_url": "https://channels.nixos.org/nixos-21.05/latest-nixos-minimal-x86_64-linux.iso",
+      "iso_checksum": "9e66b8f763cf66ca1ce0f0556e52466c91b68a58b503b086348017ace04f2437",
       "memory": "{{ user `memory` }}",
       "disk_size": "{{ user `disk_size` }}",
       "guest_os_type": "Linux"
@@ -133,7 +133,7 @@
           "qemu",
           "hyperv-iso"
         ],
-        "output": "nixos-20.09-{{.Provider}}-x86_64.box"
+        "output": "nixos-21.05-{{.Provider}}-x86_64.box"
       }
     ]
   ]

--- a/scripts/configuration.nix
+++ b/scripts/configuration.nix
@@ -59,6 +59,7 @@
     openssh.authorizedKeys.keys = [
           "ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA6NF8iallvQVp22WDkTkyrtvp9eWW6A8YVr+kz4TjGYe7gHzIw+niNltGEFHzD8+v1I2YJ6oXevct1YeS0o9HZyN1Q9qgCgzUFtdOKLv6IedplqoPkcmF0aYet2PkEDo3MlTBckFXPITAMzF8dJSIFo9D8HfdOV0IAdx4O7PtixWKn5y2hMNG0zQPyUecp4pzC6kivAIhyfHilFR61RGL+GPXQ2MWZWFYbAGjyiYJnAmCP3NOTd0jMZEnDkbUvxhMmBYSdETk1rRgm+R4LOzFUGaHqHDLKLX+FIPKcF96hrucXzcWyLbIbEgE98OHlnVYCzRdK8jlqm8tehUc9c9WhQ== vagrant insecure public key"
     ];
+    isNormalUser = true;
   };
 
   security.sudo.extraConfig =


### PR DESCRIPTION
- Updates the ISO URLs for 21.05 release of NixOS (`make update`).
- Fixes error while building:

```
…
    virtualbox-iso: building the configuration in /mnt/etc/nixos/configuration.nix...
==> virtualbox-iso: error:
==> virtualbox-iso: Failed assertions:
==> virtualbox-iso: - Exactly one of users.users.vagrant.isSystemUser and users.users.vagrant.isNormalUser must be set.
==> virtualbox-iso:
==> virtualbox-iso: (use '--show-trace' to show detailed location information)
…
```