### PR TITLE
For virtualbox-iso, use SSH key pair automation

### DIFF
--- a/nixos.pkr.hcl
+++ b/nixos.pkr.hcl
@@ -90,7 +90,7 @@ source "qemu" "qemu" {
 source "virtualbox-iso" "virtualbox" {
   boot_command         = [
     "mkdir -m 0700 .ssh<enter>",
-    "curl http://{{ .HTTPIP }}:{{ .HTTPPort }}/install_ed25519.pub > .ssh/authorized_keys<enter>",
+    "echo '{{ .SSHPublicKey }}' > .ssh/authorized_keys<enter>",
     "sudo systemctl start sshd<enter>"
   ]
   boot_wait            = "45s"


### PR DESCRIPTION
The VirtualBox builders can inject the current SSH key pair's public key into the template using the SSHPublicKey template engine.

This is more reliable than using curl.